### PR TITLE
change the way sensor values are computed

### DIFF
--- a/xiaomi-vacuum-card.js
+++ b/xiaomi-vacuum-card.js
@@ -108,8 +108,8 @@
             if (this.state.attributes[field] === undefined || this.state.attributes[field] === false) {
                 return null;
             } else if (this.stateObj && this.state.attributes[field] in this.stateObj.attributes) {
-                const computed = this.state.computeValue(this.stateObj.attributes[this.state.attributes[field]]);
-                const unit = typeof computed === 'number' ? ` ${this.state.labels.hours}` : '';
+                const computed = parseFloat(this.state.computeValue(this.stateObj.attributes[this.state.attributes[field]]));
+                const unit = ${this.state.labels.hours};
                 return `${this.state.labels[field]}: ${computed}${unit}`;
             } else {
                 return `${this.state.labels[field]}: - `;


### PR DESCRIPTION
Hi.
I use a Xiaomi Vacuum Gen1 with Valetudo 0.4.0 on HA 0.107.7. As I installed the lovelace card I noticed that there is no unit for the sensor values. The content of the value `computed` was like `"72.7"`. There was a check if the computed value is a number, but the `parseFloat()` ([more infos](https://gomakethings.com/converting-strings-to-numbers-with-vanilla-javascript/#parsefloat)) method will parse every type of value to a float value. Then we can add the unit and we are ready. Hopefully it's also valid for the other platforms.
Can a few people check it out?