### PR TITLE
add vendor deebot_slim

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ If you think any more vendors should be added, feel free to open an issue or con
 
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------
-| vendor | string | `xiaomi` | Supported vendors: `xiaomi`, `valetudo`, `ecovacs`, `deebot`, `robovac`, `roomba`
+| vendor | string | `xiaomi` | Supported vendors: `xiaomi`, `valetudo`, `ecovacs`, `deebot`, `deebot_slim`, `robovac`, `roomba`
 
 *Note: Vendor `ecovacs` and `robovac` shows the clean spot button instead of the stop button by default*
 

--- a/tracker.json
+++ b/tracker.json
@@ -1,7 +1,7 @@
 {
   "xiaomi-vacuum-card": {
     "updated_at": "2020-01-11",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "remote_location": "https://raw.githubusercontent.com/benct/lovelace-xiaomi-vacuum-card/master/xiaomi-vacuum-card.js",
     "visit_repo": "https://github.com/benct/lovelace-xiaomi-vacuum-card",
     "changelog": "https://github.com/benct/lovelace-xiaomi-vacuum-card/blob/master/CHANGELOG.md"

--- a/xiaomi-vacuum-card.js
+++ b/xiaomi-vacuum-card.js
@@ -248,6 +248,20 @@
                         sensor: false,
                     },
                     computeValue: v => Math.round(Number(v) / 100),
+                },
+                deebot_slim: {
+                    image: '/local/img/vacuum_ecovacs.png',
+                    details: true,
+                    service: {
+                        start: 'turn_on',
+                        pause: 'stop',
+                        stop: 'turn_off',
+                    },
+                    attributes: {
+                        side_brush: 'component_side_brush',
+                        filter: 'component_filter',
+                        sensor: false,
+                    },
                 }
             };
 


### PR DESCRIPTION
Hello,

I have an _ecovacs deebot slim 2_ (I call it Bob), which provides `component_side_brush `and `component_filter `in full hours, therefore no extra calculation on values is needed. In addition, the deebot slim series has no main brush equiped, therefore the translation of key-name is not needed. I would love to remove the field for the main brush from view, but my JavaScript skills are very limited :)

entity data of my `vacuum.bob`
```
fan_speed_list:
  - normal
  - high
battery_level: 100
battery_icon: 'mdi:battery-charging-100'
fan_speed: normal
status: charging
error: null
component_side_brush: 35
component_filter: 18
friendly_name: Bob
supported_features: 2043
```

as you could see, usage counter for side brush and filter is now correct, but main brush has no value:

![grafik](https://user-images.githubusercontent.com/35783820/92663156-c5a9a380-f300-11ea-823d-09eebbca9bb7.png)
