### PR TITLE
Generalization of drop down rendering and entity information support

### DIFF
--- a/xiaomi-vacuum-card.js
+++ b/xiaomi-vacuum-card.js
@@ -289,8 +289,9 @@
                 : this._hass.localize('state.default.unavailable');
             const attribute = html`<div>${data.icon && this.renderIcon(data)}${(data.label || '') + value}</div>`;
 
-            return (isValid && data.key === 'fan_speed' && 'fan_speed_list' in this.stateObj.attributes)
-                //|| (data.key === 'water_speed' && 'water_speed_list' in this.stateObj.attributes))
+            return (isValid && 
+                (data.key === 'fan_speed' && 'fan_speed_list' in this.stateObj.attributes)
+                || (data.key === 'water_speed' && 'water_speed_list' in this.stateObj.attributes))
                 ? this.renderMode(attribute, data.key) : attribute;
 
         }
@@ -315,13 +316,11 @@
         renderMode(attribute, attribute_name) {
             const selected = this.stateObj.attributes[attribute_name];
             const list = this.stateObj.attributes[attribute_name + "_list"];
-            console.error(selected);
-            console.error(list);
 
             return html`
               <paper-menu-button slot="dropdown-trigger" @click="${e => e.stopPropagation()}" style="padding: 0">
                 <paper-button slot="dropdown-trigger">${attribute}</paper-button>
-                <paper-listbox slot="dropdown-content" selected="${list.indexOf(selected)}" @click="${e => this.handleChange(e, selected)}">
+                <paper-listbox slot="dropdown-content" selected="${list.indexOf(selected)}" @click="${e => this.handleChange(e, attribute_name)}">
                   ${list.map(item => html`<paper-item value="${item}" style="text-shadow: none;>${item}</paper-item>`)}
                 </paper-listbox>
               </paper-menu-button>

--- a/xiaomi-vacuum-card.js
+++ b/xiaomi-vacuum-card.js
@@ -291,7 +291,7 @@
 
             return (isValid && data.key === 'fan_speed' && 'fan_speed_list' in this.stateObj.attributes)
                 //|| (data.key === 'water_speed' && 'water_speed_list' in this.stateObj.attributes))
-                ? this.renderMode(attribute, this.stateObj.attributes.fan_speed, this.stateObj.attributes.fan_speed_list) : attribute;
+                ? this.renderMode(attribute, data.key) : attribute;
 
         }
 
@@ -312,7 +312,10 @@
                 : null;
         }
 
-        renderMode(attribute, selected, list) {
+        renderMode(attribute, attribute_name) {
+            const selected = this.stateObj.attributes[attribute_name];
+            const list = this.stateObj.attributes[attribute_name + "_list"];
+
             return html`
               <paper-menu-button slot="dropdown-trigger" @click="${e => e.stopPropagation()}" style="padding: 0">
                 <paper-button slot="dropdown-trigger">${attribute}</paper-button>

--- a/xiaomi-vacuum-card.js
+++ b/xiaomi-vacuum-card.js
@@ -289,11 +289,11 @@
                 : this._hass.localize('state.default.unavailable');
             const attribute = html`<div>${data.icon && this.renderIcon(data)}${(data.label || '') + value}</div>`;
 
-            return (isValid && 
-                (data.key === 'fan_speed' && 'fan_speed_list' in this.stateObj.attributes)
-                || (data.key === 'water_speed' && 'water_speed_list' in this.stateObj.attributes))
-                ? this.renderMode(attribute, data.key) : attribute;
+            const hasDropdown = data.key + "_list" in this.stateObj.attributes;
 
+            return (isValid && hasDropdown) 
+                ? this.renderMode(attribute, data.key) 
+                : attribute;
         }
 
         renderIcon(data) {
@@ -321,7 +321,7 @@
               <paper-menu-button slot="dropdown-trigger" @click="${e => e.stopPropagation()}" style="padding: 0">
                 <paper-button slot="dropdown-trigger">${attribute}</paper-button>
                 <paper-listbox slot="dropdown-content" selected="${list.indexOf(selected)}" @click="${e => this.handleChange(e, attribute_name)}">
-                  ${list.map(item => html`<paper-item value="${item}" style="text-shadow: none;>${item}</paper-item>`)}
+                  ${list.map(item => html`<paper-item value="${item}" style="text-shadow: none;">${item}</paper-item>`)}
                 </paper-listbox>
               </paper-menu-button>
             `;

--- a/xiaomi-vacuum-card.js
+++ b/xiaomi-vacuum-card.js
@@ -291,7 +291,7 @@
 
             return (isValid && data.key === 'fan_speed' && 'fan_speed_list' in this.stateObj.attributes)
                 //|| (data.key === 'water_speed' && 'water_speed_list' in this.stateObj.attributes))
-                ? this.renderMode(attribute, computeFunc(this.stateObj.attributes[data.key]), computeFunc(this.stateObj.attributes[data.key + '_list'])) : attribute;
+                ? this.renderMode(attribute, this.stateObj.attributes.fan_speed, this.stateObj.attributes.fan_speed_list) : attribute;
 
         }
 

--- a/xiaomi-vacuum-card.js
+++ b/xiaomi-vacuum-card.js
@@ -370,7 +370,7 @@
 
         handleChange(e, attribute_name) {
             const mode = e.target.getAttribute('value');
-            this.callService('vacuum.set_' + attribute_name, {entity_id: this.stateObj.entity_id, attribute_name: mode});
+            this.callService('vacuum.set_' + attribute_name, {entity_id: this.stateObj.entity_id, [attribute_name]: mode});
         }
 
         callService(service, data = {entity_id: this.stateObj.entity_id}) {

--- a/xiaomi-vacuum-card.js
+++ b/xiaomi-vacuum-card.js
@@ -292,7 +292,7 @@
             return (isValid && 
                 (data.key === 'fan_speed' && 'fan_speed_list' in this.stateObj.attributes)
                 || (data.key === 'water_speed' && 'water_speed_list' in this.stateObj.attributes))
-                ? this.renderMode(attribute, this.stateObj.attributes[data.key], this.stateObj.attributes[data.key + 'list']) : attribute;
+                ? this.renderMode(attribute, this.stateObj.attributes[data.key], this.stateObj.attributes[data.key + '_list']) : attribute;
 
         }
 

--- a/xiaomi-vacuum-card.js
+++ b/xiaomi-vacuum-card.js
@@ -315,6 +315,8 @@
         renderMode(attribute, attribute_name) {
             const selected = this.stateObj.attributes[attribute_name];
             const list = this.stateObj.attributes[attribute_name + "_list"];
+            console.error(selected);
+            console.error(list);
 
             return html`
               <paper-menu-button slot="dropdown-trigger" @click="${e => e.stopPropagation()}" style="padding: 0">

--- a/xiaomi-vacuum-card.js
+++ b/xiaomi-vacuum-card.js
@@ -289,10 +289,9 @@
                 : this._hass.localize('state.default.unavailable');
             const attribute = html`<div>${data.icon && this.renderIcon(data)}${(data.label || '') + value}</div>`;
 
-            return (isValid && 
-                (data.key === 'fan_speed' && 'fan_speed_list' in this.stateObj.attributes)
-                || (data.key === 'water_speed' && 'water_speed_list' in this.stateObj.attributes))
-                ? this.renderMode(attribute, this.stateObj.attributes[data.key], this.stateObj.attributes[data.key + '_list']) : attribute;
+            return (isValid && data.key === 'fan_speed' && 'fan_speed_list' in this.stateObj.attributes)
+                //|| (data.key === 'water_speed' && 'water_speed_list' in this.stateObj.attributes))
+                ? this.renderMode(attribute, computeFunc(this.stateObj.attributes[data.key]), computeFunc(this.stateObj.attributes[data.key + '_list'])) : attribute;
 
         }
 

--- a/xiaomi-vacuum-card.js
+++ b/xiaomi-vacuum-card.js
@@ -278,16 +278,19 @@
 
         renderAttribute(data) {
             const computeFunc = data.compute || (v => v);
-            const isValid = data && data.key in this.stateObj.attributes;
+            const isValidAttribute = data && data.key in this.stateObj.attributes;
+            const isValidEntityData = data && data.key in this.stateObj;
 
-            const value = isValid
+            const value = isValidAttribute
                 ? computeFunc(this.stateObj.attributes[data.key]) + (data.unit || '')
-                : this._hass.localize('state.default.unavailable');
+                : isValidEntityData
+                  ? computeFunc(this.stateObj[data.key]) + (data.unit || '')
+                  : this._hass.localize('state.default.unavailable');
             const attribute = html`<div>${data.icon && this.renderIcon(data)}${(data.label || '') + value}</div>`;
 
             const hasDropdown = data.key + "_list" in this.stateObj.attributes;
 
-            return (isValid && hasDropdown) 
+            return ((isValidAttribute || isValidEntityData) && hasDropdown) 
                 ? this.renderDropdown(attribute, data.key) 
                 : attribute;
         }

--- a/xiaomi-vacuum-card.js
+++ b/xiaomi-vacuum-card.js
@@ -18,10 +18,6 @@
         mode: {
             key: 'fan_speed',
             icon: 'mdi:fan',
-        },
-        water_speed: {
-            key: "water_speed",
-            icon: 'mdi:fan'
         }
     };
 
@@ -316,6 +312,7 @@
         renderMode(attribute, attribute_name) {
             const selected = this.stateObj.attributes[attribute_name];
             const list = this.stateObj.attributes[attribute_name + "_list"];
+            console.error(this.config.entity);
 
             return html`
               <paper-menu-button slot="dropdown-trigger" @click="${e => e.stopPropagation()}" style="padding: 0">

--- a/xiaomi-vacuum-card.js
+++ b/xiaomi-vacuum-card.js
@@ -19,6 +19,10 @@
             key: 'fan_speed',
             icon: 'mdi:fan',
         },
+        water_speed: {
+            key: "water_speed",
+            icon: 'mdi:fan'
+        }
     };
 
     const attributes = {
@@ -285,8 +289,10 @@
                 : this._hass.localize('state.default.unavailable');
             const attribute = html`<div>${data.icon && this.renderIcon(data)}${(data.label || '') + value}</div>`;
 
-            return (isValid && data.key === 'fan_speed' && 'fan_speed_list' in this.stateObj.attributes)
-                ? this.renderMode(attribute) : attribute;
+            return (isValid && 
+                (data.key === 'fan_speed' && 'fan_speed_list' in this.stateObj.attributes)
+                || (data.key === 'water_speed' && 'water_speed_list' in this.stateObj.attributes))
+                ? this.renderMode(attribute, this.stateObj.attributes[data.key], this.stateObj.attributes[data.key + 'list']) : attribute;
 
         }
 
@@ -307,15 +313,12 @@
                 : null;
         }
 
-        renderMode(attribute) {
-            const selected = this.stateObj.attributes.fan_speed;
-            const list = this.stateObj.attributes.fan_speed_list;
-
+        renderMode(attribute, selected, list) {
             return html`
               <paper-menu-button slot="dropdown-trigger" @click="${e => e.stopPropagation()}" style="padding: 0">
                 <paper-button slot="dropdown-trigger">${attribute}</paper-button>
-                <paper-listbox slot="dropdown-content" selected="${list.indexOf(selected)}" @click="${e => this.handleChange(e)}">
-                  ${list.map(item => html`<paper-item value="${item}" style="text-shadow: none;">${item}</paper-item>`)}
+                <paper-listbox slot="dropdown-content" selected="${list.indexOf(selected)}" @click="${e => this.handleChange(e, selected)}">
+                  ${list.map(item => html`<paper-item value="${item}" style="text-shadow: none;>${item}</paper-item>`)}
                 </paper-listbox>
               </paper-menu-button>
             `;
@@ -365,9 +368,9 @@
             this._hass = hass;
         }
 
-        handleChange(e) {
+        handleChange(e, attribute_name) {
             const mode = e.target.getAttribute('value');
-            this.callService('vacuum.set_fan_speed', {entity_id: this.stateObj.entity_id, fan_speed: mode});
+            this.callService('vacuum.set_' + attribute_name, {entity_id: this.stateObj.entity_id, attribute_name: mode});
         }
 
         callService(service, data = {entity_id: this.stateObj.entity_id}) {

--- a/xiaomi-vacuum-card.js
+++ b/xiaomi-vacuum-card.js
@@ -18,7 +18,7 @@
         mode: {
             key: 'fan_speed',
             icon: 'mdi:fan',
-        }
+        },
     };
 
     const attributes = {
@@ -288,7 +288,7 @@
             const hasDropdown = data.key + "_list" in this.stateObj.attributes;
 
             return (isValid && hasDropdown) 
-                ? this.renderMode(attribute, data.key) 
+                ? this.renderDropdown(attribute, data.key) 
                 : attribute;
         }
 
@@ -309,10 +309,9 @@
                 : null;
         }
 
-        renderMode(attribute, attribute_name) {
+        renderDropdown(attribute, attribute_name) {
             const selected = this.stateObj.attributes[attribute_name];
             const list = this.stateObj.attributes[attribute_name + "_list"];
-            console.error(this.config.entity);
 
             return html`
               <paper-menu-button slot="dropdown-trigger" @click="${e => e.stopPropagation()}" style="padding: 0">


### PR DESCRIPTION
The proposed change allows me to add support for custom drop down types.
Included is an example gif of the feature in action.

![qXhKKp22wV](https://user-images.githubusercontent.com/10920052/107293204-7d3b1100-6a6b-11eb-8ed3-e8308d83b7e7.gif)

Please note that I have to click the dropdown twice for the value to update. (However, this seems to be an issue in the base card as well, might be my vacuum integration).

I've also added support so it is possible to directly retrieve information from the entity itself. This allows you to retrieve the actual entity state instead of the state attribute. It is still possible to retrieve the state through the attributes themselves as the attributes are checked first, and only then it checks for an item on the entity itself.