### PR TITLE
Added vendor: Dreame

### DIFF
--- a/xiaomi-vacuum-card.js
+++ b/xiaomi-vacuum-card.js
@@ -184,6 +184,32 @@
                 sensor: false,
             },
         },
+        dreame: {
+            buttons: {
+                start: {service: 'vacuum.turn_on'},
+                pause: {service: 'vacuum.stop'},
+                stop: {service: 'vacuum.turn_off'},
+            },
+            attributes: {
+                main_brush: {
+                    key: 'main_brush_life_level',
+                    unit: '%'
+                },
+                side_brush: {
+                    key: 'side_brush_life_level',
+                    unit: '%'
+                },
+                filter: {
+                    key: 'filter_life_level',
+                    unit: '%'
+                },
+                sensor: {
+                    key: 'waterbox',
+                    label: 'Mop',
+                    unit: ''
+                }
+            }
+        },
         neato: {
             state: {
                 mode: false,

--- a/xiaomi-vacuum-card.js
+++ b/xiaomi-vacuum-card.js
@@ -205,7 +205,7 @@
                 },
                 sensor: {
                     key: 'waterbox',
-                    label: 'Mop',
+                    label: 'Mop: ',
                     unit: ''
                 }
             }


### PR DESCRIPTION
I've added a new vendor Dreame - config has been tested with Dreame F9 and should also work with all robots supported by https://github.com/microfrost1/xiaomi_vacuum