### PR TITLE
external battery entity support and minor code correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ to `<config>/www/img/` or configure your own preferred path.
 | type | string | **Required** | `custom:xiaomi-vacuum-card`
 | entity | string | **Required** | `vacuum.my_xiaomi_vacuum`
 | name | string/bool | `friendly_name` | Override friendly name (set to `false` to hide)
+| battery_entity | string | *(see below)* | Battery state from external sensor
 | image | string/bool | `false` | Set path/filename of background image (i.e. `/local/img/vacuum.png`)
 | state | [Entity Data](#entity-data) | *(see below)* | Set to `false` to hide all states
 | attributes | [Entity Data](#entity-data) | *(see below)* | Set to `false` to hide all attributes
@@ -215,6 +216,14 @@ Translations:
       label: Stopp!
     stop:
       label: Hammertime
+```
+battery_entity:
+Note: battery level was moved from an attribute to a sensor in many integrations, see (https://developers.home-assistant.io/blog/2025/07/02/vacuum-battery-properties-deprecated/)
+```yaml
+- type: custom:xiaomi-vacuum-card
+  entity: vacuum.xiaomi_vacuum_cleaner
+  battery_entity: sensor.vacuum_cleaner_battery
+  vendor: valetudo
 ```
 
 ## Disclaimer

--- a/xiaomi-vacuum-card.js
+++ b/xiaomi-vacuum-card.js
@@ -287,6 +287,11 @@
             const isValidSensorData = data && `${this.config.sensorEntity}_${data.key}` in this._hass.states;
             const isValidAttribute = data && data.key in this.stateObj.attributes;
             const isValidEntityData = data && data.key in this.stateObj;
+            // NEW battery override support
+            const externalBattery =
+                data.key === 'battery_level' &&
+                this.config.battery_entity &&
+                this.config.battery_entity in this._hass.states;
 
             const value = isValidSensorData
                 ? computeFunc(this._hass.states[`${this.config.sensorEntity}_${data.key}`].state) + (data.unit || '')
@@ -295,6 +300,10 @@
                     : isValidEntityData
                         ? computeFunc(this.stateObj[data.key]) + (data.unit || '')
                         : null;
+            // --- NEW: override with external battery value ---
+            if (externalBattery) {
+               value = computeFunc(this._hass.states[this.config.battery_entity].state) + (data.unit || '');
+            }
             const attribute = html`<div>
                 ${data.icon && this.renderIcon(data)}
                 ${(data.label || '') + (value !== null ? value : this._hass.localize('state.default.unavailable'))}
@@ -369,6 +378,7 @@
                 name: config.name,
                 entity: config.entity,
                 sensorEntity: `sensor.${config.entity.split('.')[1]}`,
+                battery_entity: config.battery_entity,
                 show: {
                     name: config.name !== false,
                     state: config.state !== false,

--- a/xiaomi-vacuum-card.js
+++ b/xiaomi-vacuum-card.js
@@ -293,7 +293,7 @@
                 this.config.battery_entity &&
                 this.config.battery_entity in this._hass.states;
 
-            const value = isValidSensorData
+            let value = isValidSensorData
                 ? computeFunc(this._hass.states[`${this.config.sensorEntity}_${data.key}`].state) + (data.unit || '')
                 : isValidAttribute
                     ? computeFunc(this.stateObj.attributes[data.key]) + (data.unit || '')
@@ -370,7 +370,7 @@
         setConfig(config) {
             if (!config.entity) throw new Error('Please define an entity.');
             if (config.entity.split('.')[0] !== 'vacuum') throw new Error('Please define a vacuum entity.');
-            if (config.vendor && !config.vendor in vendors) throw new Error('Please define a valid vendor.');
+            if (config.vendor && !(config.vendor in vendors)) throw new Error('Please define a valid vendor.');
 
             const vendor = vendors[config.vendor] || vendors.xiaomi;
 


### PR DESCRIPTION
fix for https://developers.home-assistant.io/blog/2025/07/02/vacuum-battery-properties-deprecated/
