### PR TITLE
Roborock reports remaining brush time in hours

### DIFF
--- a/xiaomi-vacuum-card.js
+++ b/xiaomi-vacuum-card.js
@@ -82,15 +82,16 @@
         trueFalse: v => (v === true ? 'Yes' : (v === false ? 'No' : '-')),
         divide100: v => Math.round(Number(v) / 100),
         secToHour: v => Math.floor(Number(v) / 60 / 60),
+        hour: v => Math.floor(Number(v)),
     }
 
     const vendors = {
         xiaomi: {
             attributes: {
-                main_brush: {compute: compute.secToHour},
-                side_brush: {compute: compute.secToHour},
-                filter: {compute: compute.secToHour},
-                sensor: {compute: compute.secToHour},
+                main_brush: {compute: compute.hour},
+                side_brush: {compute: compute.hour},
+                filter: {compute: compute.hour},
+                sensor: {compute: compute.hour},
             }
         },
         xiaomi_mi: {
@@ -250,6 +251,7 @@
   font-size: 110%;
   padding-left: 10px;
   border-left: 2px solid var(--primary-color);
+  text-transform: capitalize;
 }
 .grid-right {
   text-align: right;


### PR DESCRIPTION
Newer Roborock vacuums report time remaining for:
- main_brush
- side_brush
- filter
- sensor

in **hours**.

I added new compute that just rounds the returned value and does not change it to seconds.

Implementation is probably not the best - it does not check which vacuum it's working with as this was only local fix for my Roborock Qrevo 5AE. Feel free to update, request changes,...